### PR TITLE
[ENHANCEMENT] Add Github Action workflow to publish docker image on Hub for amd64 & arm64

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,37 @@
+# Based on https://github.com/matrix-org/dendrite/blob/master/.github/workflows/docker-hub.yml
+
+name: "Docker Hub - Latest"
+
+on:
+  push:
+
+env:
+  DOCKER_NAMESPACE: kelaresg
+  PLATFORMS: linux/amd64,linux/arm64
+  # Only push if this is main, otherwise we just want to build
+  PUSH: ${{ github.ref == 'refs/heads/main' }}
+
+jobs:
+  docker-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: ${{ env.PUSH }}
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/go-skype-bridge:latest


### PR DESCRIPTION
As explained in the title, the idea is to propose a pre-built image directly on Docker Hub.

For this all to work, it'll require to add corresponding secrets (`DOCKER_HUB_USERNAME` `DOCKER_HUB_TOKEN`) in the repository :) 