### PR TITLE
added report_connection_success flag

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -26,6 +26,7 @@ type BridgeConfig struct {
 	MaxConnectionAttempts int  `yaml:"max_connection_attempts"`
 	ConnectionRetryDelay  int  `yaml:"connection_retry_delay"`
 	ReportConnectionRetry bool `yaml:"report_connection_retry"`
+	ReportConnectionSuccess	bool `yaml:"report_connection_success"`
 	ChatListWait          int  `yaml:"chat_list_wait"`
 	PortalSyncWait        int  `yaml:"portal_sync_wait"`
 
@@ -91,6 +92,7 @@ func (bc *BridgeConfig) setDefaults() {
 	bc.MaxConnectionAttempts = 3
 	bc.ConnectionRetryDelay = -1
 	bc.ReportConnectionRetry = true
+	bc.ReportConnectionSuccess = true
 	bc.ChatListWait = 30
 	bc.PortalSyncWait = 600
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -94,6 +94,8 @@ bridge:
     # Whether or not the bridge should send a notice to the user's management room when it retries connecting.
     # If false, it will only report when it stops retrying.
     report_connection_retry: true
+    # Whether or not the bridge should send a notice to the user's management room when it logins successfully.
+    report_connection_success: true
     # Maximum number of seconds to wait for chats to be sent at startup.
     # If this is too low and you have lots of chats, it could cause backfilling to fail.
     chat_list_wait: 30

--- a/user.go
+++ b/user.go
@@ -382,7 +382,10 @@ func (user *User) Login(ce *CommandEvent, name string, password string) (err err
 	} else {
 		orgId = strings.TrimSuffix(user.JID, skypeExt.NewUserSuffix)
 	}
-	ce.Reply("Successfully logged in as @" + username + ", orgid is " + orgId)
+
+	if user.bridge.Config.Bridge.ReportConnectionSuccess {
+		ce.Reply("Successfully logged in as @" + username + ", orgid is " + orgId)
+	}
 
 	user.Conn.Subscribes() // subscribe basic event
 	err = user.Conn.ContactList(user.Conn.UserProfile.Username)


### PR DESCRIPTION
I added a flag to hide the 'successfully logged in' message I was getting every day (it was a bit annoying 😛)
